### PR TITLE
Change collection migrate and share labels

### DIFF
--- a/cwrc_islandora_tweaks.module
+++ b/cwrc_islandora_tweaks.module
@@ -207,9 +207,31 @@ function cwrc_islandora_tweaks_form_alter(&$form, &$form_state, $form_id) {
       $value = str_replace(array('CModel', 'Content Model'), '', $value);
     }
   }
-  if ($form_id == 'islandora_basic_collection_share_children_form' || $form_id == 'islandora_basic_collection_migrate_children_form') {
+  if ($form_id == 'islandora_basic_collection_share_children_form'
+    || $form_id == 'islandora_basic_collection_migrate_children_form') {
     $form['collection']['#required'] = 1;
     $form['collection']['#empty_option'] = '- '. t('Choose a Collection') . ' -';
+
+    // Iterate over pre-populated options.
+    foreach ($form['collection']['#options'] as $pid => $label) {
+      // Load the object and get the parent pids.
+      $object = islandora_object_load($pid);
+      $parent_pids = islandora_basic_collection_get_parent_pids($object);
+
+      // Build an array of parent labels.
+      $parent_labels = array();
+      foreach ($parent_pids as $parent_pid) {
+        $parent = islandora_object_load($parent_pid);
+        $parent_labels[] = $parent->label;
+      }
+
+      // Change the option label to new format.
+      $form['collection']['#options'][$pid] = t('@label [@parents] (@pid)', array(
+        '@label' => $label,
+        '@parents' =>  implode(', ', $parent_labels),
+        '@pid' => $pid,
+      ));
+    }
   }
   if ($form_id == 'islandora_basic_collection_share_item_form'
     || $form_id == 'islandora_basic_collection_migrate_item_form') {

--- a/cwrc_islandora_tweaks.module
+++ b/cwrc_islandora_tweaks.module
@@ -211,7 +211,8 @@ function cwrc_islandora_tweaks_form_alter(&$form, &$form_state, $form_id) {
     $form['collection']['#required'] = 1;
     $form['collection']['#empty_option'] = '- '. t('Choose a Collection') . ' -';
   }
-  if ($form_id == 'islandora_basic_collection_share_children_form' || 'islandora_basic_collection_migrate_item_form' ) {
+  if ($form_id == 'islandora_basic_collection_share_item_form'
+    || $form_id == 'islandora_basic_collection_migrate_item_form') {
     $form['new_collection_name']['#autocomplete_path'] = 'islandora/basic_collection/find_collections_user';
   }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -25,17 +25,17 @@ EOQ;
 
     $object = islandora_object_load($objects['pid']['value']);
     $parents = islandora_basic_collection_get_parent_pids($object);
-    $parents_label = '';
+    $parent_labels = array();
     foreach ($parents as $parent) {
       $parent_object = islandora_object_load($parent);
-      $parents_label .= ' (' . $parent_object->label .')';
+      $parent_labels[] = $parent_object->label;
     }
     $access = islandora_xacml_editor_islandora_object_access('administer islandora_xacml_editor',$object, $user);
 
-    $return[$objects['pid']['value']] = t('@label @parents [@pid]', array(
+    $return[$objects['pid']['value']] = t('@label [@parents] (@pid)', array(
       '@label' => $objects['label']['value'],
+      '@parents' =>  implode(', ', $parent_labels),
       '@pid' => $objects['pid']['value'],
-      '@parents' =>  $parents_label,
     ));
 
     $object = islandora_object_load($objects['pid']['value']);


### PR DESCRIPTION
Changes the labels of autocomplete and drop-down collection forms to use the following format:

`@label [@parents] (@pid)`

For example:

`Basic Image Collection [Top-level Collection] (islandora:sp_basic_image_collection)`

When an object has more than one parent they are separated by a comma.