### PR TITLE
Null object error on collection details lookup

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -24,25 +24,27 @@ EOQ;
   foreach ($results as $objects) {
 
     $object = islandora_object_load($objects['pid']['value']);
-    $parents = islandora_basic_collection_get_parent_pids($object);
-    $parent_labels = array();
-    foreach ($parents as $parent) {
-      $parent_object = islandora_object_load($parent);
-      $parent_labels[] = $parent_object->label;
-    }
-    $access = islandora_xacml_editor_islandora_object_access('administer islandora_xacml_editor',$object, $user);
-
-    $return[$objects['pid']['value']] = t('@label [@parents] (@pid)', array(
-      '@label' => $objects['label']['value'],
-      '@parents' =>  implode(', ', $parent_labels),
-      '@pid' => $objects['pid']['value'],
-    ));
-
-    $object = islandora_object_load($objects['pid']['value']);
-    $access = islandora_xacml_editor_islandora_object_access('administer islandora_xacml_editor',$object, $user);
-
-    if(empty($access)) {
-      unset($return[$objects['pid']['value']]);
+    if (isset($object)) {
+      $parents = islandora_basic_collection_get_parent_pids($object);
+      $parent_labels = array();
+      foreach ($parents as $parent) {
+        $parent_object = islandora_object_load($parent);
+        $parent_labels[] = $parent_object->label;
+      }
+      $access = islandora_xacml_editor_islandora_object_access('administer islandora_xacml_editor',$object, $user);
+  
+      $return[$objects['pid']['value']] = t('@label [@parents] (@pid)', array(
+        '@label' => $objects['label']['value'],
+        '@parents' =>  implode(', ', $parent_labels),
+        '@pid' => $objects['pid']['value'],
+      ));
+  
+      $object = islandora_object_load($objects['pid']['value']);
+      $access = islandora_xacml_editor_islandora_object_access('administer islandora_xacml_editor',$object, $user);
+  
+      if(empty($access)) {
+        unset($return[$objects['pid']['value']]);
+      }
     }
   }
   drupal_json_output($return);


### PR DESCRIPTION
handle case where current user doesn't have access an object and object is null - fixes #17

# Problem / motivation

A user aims to migrate an object into another collection. The auto-populate textbox offers autocomplete options but returns a 500 error when trying to lookup the details of a collection the current user does not have `view` permissions on.

# Proposed resolution

Enhance error checking to prevent a null object (due to access restrictions) passed into collection list
