### PR TITLE
Clean menu item(s) related to an islandora object when it is deleted

### DIFF
--- a/cwrc_islandora_tweaks.module
+++ b/cwrc_islandora_tweaks.module
@@ -127,6 +127,17 @@ function cwrc_islandora_tweaks_islandora_sp_audiocmodel_islandora_object_ingeste
   cwrc_islandora_tweaks_islandora_object_ingested($object);
 }
 
+/**
+ * Implements hook_islandora_object_purged().
+ */
+function cwrc_islandora_tweaks_islandora_object_purged($pid) {
+  // Delete all menu module links that point to this object pid.
+  $result = db_query("SELECT mlid FROM {menu_links} WHERE link_path = :path AND module = 'menu'", array(':path' => 'islandora/object/' . $pid), array('fetch' => PDO::FETCH_ASSOC));
+  foreach ($result as $m) {
+    menu_link_delete($m['mlid']);
+  }
+}
+
 /* Form handlers. */
 
 /**


### PR DESCRIPTION
# Problem / motivation

When an islandora object is deleted if there is a menu item linked to it, that menu item still available in the database.

# Proposed resolution

Implement a hook_islandora_object_purged() which takes care of deleting menu items associated with the deleted islandora object

# Remaining tasks

- [ ] Update "Remaining tasks"
- [x] Implement the hook
- [ ] Code review
- [ ] Commit
- [ ] Deploy 